### PR TITLE
Refactoring of TDE/QBV processors

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,4 @@ mlAppName=ml-javaclient-util-test
 mlRestPort=8028
 mlUsername=admin
 mlPassword=change in gradle-local.properties
+mlConfigPaths=src/test/ml-config

--- a/src/main/java/com/marklogic/client/ext/helper/FilenameUtil.java
+++ b/src/main/java/com/marklogic/client/ext/helper/FilenameUtil.java
@@ -20,16 +20,29 @@ import java.io.File;
 public abstract class FilenameUtil {
 
     public static boolean isXslFile(String filename) {
-        return filename.endsWith(".xsl") || filename.endsWith(".xslt");
+		return endsWithExtension(filename, ".xsl", ".xslt");
     }
 
     public static boolean isXqueryFile(String filename) {
-        return filename.endsWith(".xqy") || filename.endsWith(".xq");
+		return endsWithExtension(filename, ".xqy", ".xqy");
     }
 
     public static boolean isJavascriptFile(String filename) {
-        return filename.endsWith(".sjs") || filename.endsWith(".js");
+		return endsWithExtension(filename, ".sjs", ".js");
     }
+
+	public static boolean endsWithExtension(String filename, String... extensions) {
+		if (filename == null || extensions == null) {
+			return false;
+		}
+		filename = filename.toLowerCase();
+		for (String extension : extensions) {
+			if (extension != null && filename.endsWith(extension.toLowerCase())) {
+				return true;
+			}
+		}
+		return false;
+	}
 
     public static String getFileExtension(File f) {
         String[] split = f.getName().split("\\.");

--- a/src/test/java/com/marklogic/client/ext/schemasloader/impl/AbstractSchemasTest.java
+++ b/src/test/java/com/marklogic/client/ext/schemasloader/impl/AbstractSchemasTest.java
@@ -26,7 +26,7 @@ public abstract class AbstractSchemasTest extends AbstractIntegrationTest {
 	 */
 	@BeforeEach
 	public void setup() {
-		client = newClient("Schemas");
+		client = newClient("ml-javaclient-util-test-schemas");
 		client.newServerEval().xquery("cts:uris((), (), cts:true-query()) ! xdmp:document-delete(.)").eval();
 	}
 

--- a/src/test/java/com/marklogic/client/ext/schemasloader/impl/GenerateQbvTest.java
+++ b/src/test/java/com/marklogic/client/ext/schemasloader/impl/GenerateQbvTest.java
@@ -3,6 +3,7 @@ package com.marklogic.client.ext.schemasloader.impl;
 import com.marklogic.client.ext.file.DocumentFile;
 import com.marklogic.client.ext.helper.ClientHelper;
 import com.marklogic.client.io.DocumentMetadataHandle;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.nio.file.Path;
@@ -14,9 +15,15 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class GenerateQbvTest extends AbstractSchemasTest {
 
+	private DefaultSchemasLoader loader;
+
+	@BeforeEach
+	void beforeEach() {
+		loader = new DefaultSchemasLoader(client, CONTENT_DATABASE);
+	}
+
 	@Test
 	public void test() {
-		DefaultSchemasLoader loader = new DefaultSchemasLoader(client, "Documents");
 		Path path = Paths.get("src", "test", "resources", "qbv-schemas");
 		List<DocumentFile> files = loader.loadSchemas(path.toString());
 		assertEquals(3, files.size(),
@@ -52,7 +59,6 @@ public class GenerateQbvTest extends AbstractSchemasTest {
 
 	@Test
 	public void loadBadOptic() {
-		DefaultSchemasLoader loader = new DefaultSchemasLoader(client, "Documents");
 		Path path = Paths.get("src", "test", "resources", "qbv-bad-schemas");
 		RuntimeException ex = assertThrows(RuntimeException.class, () -> loader.loadSchemas(path.toString()));
 		assertTrue(ex.getMessage().contains("Query-Based View generation failed for file:"), "Unexpected message: " + ex.getMessage());
@@ -62,7 +68,6 @@ public class GenerateQbvTest extends AbstractSchemasTest {
 
 	@Test
 	public void schemaViewDoesNotExist() {
-		DefaultSchemasLoader loader = new DefaultSchemasLoader(client, "Documents");
 		Path path = Paths.get("src", "test", "resources", "qbv-no-tde-schemas");
 		RuntimeException ex = assertThrows(RuntimeException.class, () -> loader.loadSchemas(path.toString()));
 		assertTrue(ex.getMessage().contains("Query-Based View generation failed for file:"), "Unexpected message: " + ex.getMessage());
@@ -72,7 +77,6 @@ public class GenerateQbvTest extends AbstractSchemasTest {
 
 	@Test
 	public void emptyDirectories() {
-		DefaultSchemasLoader loader = new DefaultSchemasLoader(client, "Documents");
 		Path path = Paths.get("src", "test", "resources", "qbv-empty-schemas");
 		List<DocumentFile> files = loader.loadSchemas(path.toString());
 		assertEquals(0, files.size());

--- a/src/test/java/com/marklogic/client/ext/schemasloader/impl/LoadSchemasTest.java
+++ b/src/test/java/com/marklogic/client/ext/schemasloader/impl/LoadSchemasTest.java
@@ -25,7 +25,9 @@ import org.junit.jupiter.api.Test;
 import java.nio.file.Paths;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LoadSchemasTest extends AbstractSchemasTest {
 
@@ -45,6 +47,9 @@ public class LoadSchemasTest extends AbstractSchemasTest {
 		assertTrue(uris.contains("/child/child.tdej"));
 		assertTrue(uris.contains("/child/grandchild/grandchild.tdex"));
 		assertTrue(uris.contains("/parent.tdex"));
+
+		// This assertion seems a little off - a TDE should be either a JSON or XML file. This doesn't seem to cause
+		// any problems, but it also doesn't seem to make sense.
 		assertTrue(uris.contains("/tde/ruleset.txt"));
 	}
 

--- a/src/test/ml-config/databases/content-database.json
+++ b/src/test/ml-config/databases/content-database.json
@@ -1,0 +1,4 @@
+{
+  "database-name": "%%DATABASE%%",
+  "schema-database": "%%SCHEMAS_DATABASE%%"
+}

--- a/src/test/ml-config/databases/schemas-database.json
+++ b/src/test/ml-config/databases/schemas-database.json
@@ -1,0 +1,3 @@
+{
+  "database-name": "%%SCHEMAS_DATABASE%%"
+}


### PR DESCRIPTION
Changes:

- Renamed client to `schemasDatabaseClient` to make it clear the kind of client that's needed.
- Using `FilenameUtil` - not the most glamorous class, but nice to have all the checks in one place. 
- Deprecated some getters/setters that I shouldn't have added. 
- Added a schemas database to the test app and changed schemas tests to use that. 

