### PR TITLE
Refactoring file loading

### DIFF
--- a/src/main/java/com/marklogic/client/ext/file/FormatDocumentFileProcessor.java
+++ b/src/main/java/com/marklogic/client/ext/file/FormatDocumentFileProcessor.java
@@ -15,13 +15,17 @@
  */
 package com.marklogic.client.ext.file;
 
+import com.marklogic.client.ext.helper.LoggingObject;
 import com.marklogic.client.io.Format;
+
+import java.util.Arrays;
 
 /**
  * Delegates to DefaultDocumentFormatGetter by default for determining what Format to use for the File in a given
  * DocumentFile.
  */
-public class FormatDocumentFileProcessor implements DocumentFileProcessor {
+public class FormatDocumentFileProcessor extends LoggingObject
+	implements DocumentFileProcessor, SupportsAdditionalBinaryExtensions {
 
 	private FormatGetter formatGetter;
 
@@ -35,12 +39,24 @@ public class FormatDocumentFileProcessor implements DocumentFileProcessor {
 
 	@Override
 	public DocumentFile processDocumentFile(DocumentFile documentFile) {
-
 		Format format = formatGetter.getFormat(documentFile.getResource());
 		if (format != null) {
 			documentFile.setFormat(format);
 		}
 		return documentFile;
+	}
+
+	@Override
+	public void setAdditionalBinaryExtensions(String[] extensions) {
+		if (formatGetter instanceof DefaultDocumentFormatGetter) {
+			DefaultDocumentFormatGetter ddfg = (DefaultDocumentFormatGetter) formatGetter;
+			for (String ext : extensions) {
+				ddfg.getBinaryExtensions().add(ext);
+			}
+		} else {
+			logger.warn("FormatGetter is not an instanceof DefaultDocumentFormatGetter, " +
+				"so unable to add additionalBinaryExtensions: " + Arrays.asList(extensions));
+		}
 	}
 
 	public FormatGetter getFormatGetter() {

--- a/src/main/java/com/marklogic/client/ext/file/PropertiesDrivenDocumentFileProcessor.java
+++ b/src/main/java/com/marklogic/client/ext/file/PropertiesDrivenDocumentFileProcessor.java
@@ -28,7 +28,8 @@ import java.util.Properties;
  * Base class for processors that look for a special file in each directory and intend to perform some processing based
  * on the contents of that file. By default, that special file is NOT loaded into MarkLogic.
  */
-public abstract class PropertiesDrivenDocumentFileProcessor extends LoggingObject implements DocumentFileProcessor, FileFilter {
+public abstract class PropertiesDrivenDocumentFileProcessor extends LoggingObject
+	implements DocumentFileProcessor, FileFilter, SupportsTokenReplacer {
 
 	protected final static String WILDCARD_KEY = "*";
 
@@ -83,6 +84,7 @@ public abstract class PropertiesDrivenDocumentFileProcessor extends LoggingObjec
 		return propertiesFilename;
 	}
 
+	@Override
 	public void setTokenReplacer(TokenReplacer tokenReplacer) {
 		this.tokenReplacer = tokenReplacer;
 	}
@@ -90,7 +92,7 @@ public abstract class PropertiesDrivenDocumentFileProcessor extends LoggingObjec
 	protected TokenReplacer getTokenReplacer() {
 		return tokenReplacer;
 	}
-
+	
 	protected void setProperties(Properties properties) {
 		this.properties = properties;
 	}

--- a/src/main/java/com/marklogic/client/ext/file/SupportsAdditionalBinaryExtensions.java
+++ b/src/main/java/com/marklogic/client/ext/file/SupportsAdditionalBinaryExtensions.java
@@ -1,0 +1,11 @@
+package com.marklogic.client.ext.file;
+
+/**
+ * Intended to allow for {@code DefaultDocumentFileReader} to pass along a user-supplied list of additional binary
+ * extensions without being coupled tightly to the {@code DocumentFileProcessor} that uses them.
+ */
+public interface SupportsAdditionalBinaryExtensions {
+
+	void setAdditionalBinaryExtensions(String[] extensions);
+
+}

--- a/src/main/java/com/marklogic/client/ext/file/SupportsTokenReplacer.java
+++ b/src/main/java/com/marklogic/client/ext/file/SupportsTokenReplacer.java
@@ -1,0 +1,12 @@
+package com.marklogic.client.ext.file;
+
+import com.marklogic.client.ext.tokenreplacer.TokenReplacer;
+
+/**
+ * Intended to be implemented by instances of {@code DocumentFileProcessor} that wish to use a
+ * {@code TokenReplacer} on the files that they read.
+ */
+public interface SupportsTokenReplacer {
+
+	void setTokenReplacer(TokenReplacer tokenReplacer);
+}


### PR DESCRIPTION
Changes:

1. The Cascading processor now implements `FileVisitor` so that DDFR can bind to that instead of the concrete classes.
2. Added two `Supports` interfaces that are a little cheesy but allow for DDFR/GFL to not be bound directly to the collections/permissions processors (though I couldn't completely remove that binding without introducing breaking changes in the public API). 