### PR TITLE
Deprecating DocumentPermissionsParser

### DIFF
--- a/src/main/java/com/marklogic/client/ext/file/PermissionsDocumentFileProcessor.java
+++ b/src/main/java/com/marklogic/client/ext/file/PermissionsDocumentFileProcessor.java
@@ -15,9 +15,8 @@
  */
 package com.marklogic.client.ext.file;
 
-import com.marklogic.client.ext.util.DefaultDocumentPermissionsParser;
-import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.ext.util.DocumentPermissionsParser;
+import com.marklogic.client.io.DocumentMetadataHandle;
 
 /**
  * DocumentFileProcessor that uses a DocumentPermissionsParser to parse a string of permissions (typically, a delimited
@@ -25,24 +24,33 @@ import com.marklogic.client.ext.util.DocumentPermissionsParser;
  */
 public class PermissionsDocumentFileProcessor implements DocumentFileProcessor {
 
-	private String permissions;
+	private String commaDelimitedRolesAndCapabilities;
 	private DocumentPermissionsParser documentPermissionsParser;
 
-	public PermissionsDocumentFileProcessor(String permissions) {
-		this(permissions, new DefaultDocumentPermissionsParser());
+	public PermissionsDocumentFileProcessor(String commaDelimitedRolesAndCapabilities) {
+		this.commaDelimitedRolesAndCapabilities = commaDelimitedRolesAndCapabilities;
 	}
 
-	public PermissionsDocumentFileProcessor(String permissions, DocumentPermissionsParser documentPermissionsParser) {
-		this.permissions = permissions;
+	/**
+	 * @param commaDelimitedRolesAndCapabilities
+	 * @param documentPermissionsParser
+	 * @deprecated since 4.6.0
+	 */
+	public PermissionsDocumentFileProcessor(String commaDelimitedRolesAndCapabilities, DocumentPermissionsParser documentPermissionsParser) {
+		this.commaDelimitedRolesAndCapabilities = commaDelimitedRolesAndCapabilities;
 		this.documentPermissionsParser = documentPermissionsParser;
 	}
 
 	@Override
 	public DocumentFile processDocumentFile(DocumentFile documentFile) {
-		if (permissions != null && documentPermissionsParser != null) {
+		if (this.commaDelimitedRolesAndCapabilities != null) {
 			DocumentMetadataHandle metadata = documentFile.getDocumentMetadata();
 			if (metadata != null) {
-				documentPermissionsParser.parsePermissions(permissions, metadata.getPermissions());
+				if (this.documentPermissionsParser != null) {
+					this.documentPermissionsParser.parsePermissions(this.commaDelimitedRolesAndCapabilities, metadata.getPermissions());
+				} else {
+					metadata.getPermissions().addFromDelimitedString(this.commaDelimitedRolesAndCapabilities);
+				}
 			}
 		}
 		return documentFile;

--- a/src/main/java/com/marklogic/client/ext/file/PermissionsFileDocumentFileProcessor.java
+++ b/src/main/java/com/marklogic/client/ext/file/PermissionsFileDocumentFileProcessor.java
@@ -15,7 +15,6 @@
  */
 package com.marklogic.client.ext.file;
 
-import com.marklogic.client.ext.util.DefaultDocumentPermissionsParser;
 import com.marklogic.client.ext.util.DocumentPermissionsParser;
 
 import java.util.Properties;
@@ -33,9 +32,15 @@ public class PermissionsFileDocumentFileProcessor extends CascadingPropertiesDri
 	}
 
 	public PermissionsFileDocumentFileProcessor(String propertiesFilename) {
-		this(propertiesFilename, new DefaultDocumentPermissionsParser());
+		super(propertiesFilename);
 	}
 
+	/**
+	 * @param propertiesFilename
+	 * @param documentPermissionsParser
+	 * @deprecated since 4.6.0
+	 */
+	@Deprecated
 	public PermissionsFileDocumentFileProcessor(String propertiesFilename, DocumentPermissionsParser documentPermissionsParser) {
 		super(propertiesFilename);
 		this.documentPermissionsParser = documentPermissionsParser;
@@ -46,15 +51,25 @@ public class PermissionsFileDocumentFileProcessor extends CascadingPropertiesDri
 		String name = documentFile.getFile().getName();
 		if (properties.containsKey(name)) {
 			String value = getPropertyValue(properties, name);
-			documentPermissionsParser.parsePermissions(value, documentFile.getDocumentMetadata().getPermissions());
+			if (documentPermissionsParser != null) {
+				documentPermissionsParser.parsePermissions(value, documentFile.getDocumentMetadata().getPermissions());
+			} else {
+				documentFile.getDocumentMetadata().getPermissions().addFromDelimitedString(value);
+			}
+
 		}
 
 		if (properties.containsKey(WILDCARD_KEY)) {
 			String value = getPropertyValue(properties, WILDCARD_KEY);
-			documentPermissionsParser.parsePermissions(value, documentFile.getDocumentMetadata().getPermissions());
+			if (documentPermissionsParser != null) {
+				documentPermissionsParser.parsePermissions(value, documentFile.getDocumentMetadata().getPermissions());
+			} else {
+				documentFile.getDocumentMetadata().getPermissions().addFromDelimitedString(value);
+			}
 		}
 	}
 
+	@Deprecated
 	public void setDocumentPermissionsParser(DocumentPermissionsParser documentPermissionsParser) {
 		this.documentPermissionsParser = documentPermissionsParser;
 	}

--- a/src/main/java/com/marklogic/client/ext/util/DefaultDocumentPermissionsParser.java
+++ b/src/main/java/com/marklogic/client/ext/util/DefaultDocumentPermissionsParser.java
@@ -15,34 +15,20 @@
  */
 package com.marklogic.client.ext.util;
 
-import com.marklogic.client.io.DocumentMetadataHandle.Capability;
 import com.marklogic.client.io.DocumentMetadataHandle.DocumentPermissions;
 
+/**
+ * @deprecated since 4.6.0, will be removed in 5.0.0. Can use the new {@code addFromDelimitedString} method in
+ * the Java Client's {@code DocumentPermissions} class in Java Client 6.3.0.
+ */
+@Deprecated
 public class DefaultDocumentPermissionsParser implements DocumentPermissionsParser {
 
 	@Override
+	@Deprecated
 	public void parsePermissions(String str, DocumentPermissions permissions) {
-		if (str != null && str.trim().length() > 0) {
-			String[] tokens = str.split(",");
-			for (int i = 0; i < tokens.length; i += 2) {
-				String role = tokens[i];
-				if (i + 1 >= tokens.length) {
-					throw new IllegalArgumentException("Unable to parse permissions string, which must be a comma-separated " +
-						"list of role names and capabilities - i.e. role1,read,role2,update,role3,execute; string: " + str);
-				}
-				Capability c;
-				try {
-					c = Capability.getValueOf(tokens[i + 1]);
-				} catch (Exception e) {
-					throw new IllegalArgumentException("Unable to parse permissions string: " + str + "; cause: " + e.getMessage());
-				}
-				if (permissions.containsKey(role)) {
-					permissions.get(role).add(c);
-				} else {
-					permissions.add(role, c);
-				}
-			}
-		}
+		// As of Java Client 6.3.0, can just defer to the client.
+		permissions.addFromDelimitedString(str);
 	}
 
 }

--- a/src/main/java/com/marklogic/client/ext/util/DocumentPermissionsParser.java
+++ b/src/main/java/com/marklogic/client/ext/util/DocumentPermissionsParser.java
@@ -17,13 +17,19 @@ package com.marklogic.client.ext.util;
 
 import com.marklogic.client.io.DocumentMetadataHandle.DocumentPermissions;
 
+/**
+ * @deprecated since 4.6.0, will be removed in 5.0.0. Can use the new {@code addFromDelimitedString} method in
+ * the Java Client's {@code DocumentPermissions} class in Java Client 6.3.0.
+ */
+@Deprecated
 public interface DocumentPermissionsParser {
 
-    /**
-     * Parse the string and add role/capability sets to the given DocumentPermissions object.
-     *
-     * @param str
-     * @param permissions
-     */
-    void parsePermissions(String str, DocumentPermissions permissions);
+	/**
+	 * Parse the string and add role/capability sets to the given DocumentPermissions object.
+	 *
+	 * @param str
+	 * @param permissions
+	 */
+	@Deprecated
+	void parsePermissions(String str, DocumentPermissions permissions);
 }


### PR DESCRIPTION
This will work once https://github.com/marklogic/java-client-api/pull/1592/files is merged into the develop branch of the Java Client. 