### PR TITLE
Can now configure whether processors cascade

### DIFF
--- a/src/main/java/com/marklogic/client/ext/file/GenericFileLoader.java
+++ b/src/main/java/com/marklogic/client/ext/file/GenericFileLoader.java
@@ -53,6 +53,8 @@ public class GenericFileLoader extends LoggingObject implements FileLoader {
 	private String[] collections;
 	private TokenReplacer tokenReplacer;
 	private String[] additionalBinaryExtensions;
+	private boolean cascadeCollections;
+	private boolean cascadePermissions;
 
 	/**
 	 * The given DatabaseClient is used to construct a BatchWriter that writes to MarkLogic via the REST API. The
@@ -186,6 +188,15 @@ public class GenericFileLoader extends LoggingObject implements FileLoader {
 			if (additionalBinaryExtensions != null && processor instanceof SupportsAdditionalBinaryExtensions) {
 				((SupportsAdditionalBinaryExtensions) processor).setAdditionalBinaryExtensions(additionalBinaryExtensions);
 			}
+
+			// Awful hack for 4.6.0. In 5.0, the hope is to replace the processor-specific fields on this class with
+			// a "Config"-type class that can be passed to each processor.
+			if (processor instanceof PermissionsFileDocumentFileProcessor) {
+				((PermissionsFileDocumentFileProcessor)processor).setCascadingEnabled(this.cascadePermissions);
+			}
+			if (processor instanceof CollectionsFileDocumentFileProcessor) {
+				((CollectionsFileDocumentFileProcessor)processor).setCascadingEnabled(this.cascadeCollections);
+			}
 		});
 	}
 
@@ -300,5 +311,37 @@ public class GenericFileLoader extends LoggingObject implements FileLoader {
 
 	public void setBatchWriter(BatchWriter batchWriter) {
 		this.batchWriter = batchWriter;
+	}
+
+	/**
+	 * @param cascadeCollections
+	 * @since 4.6.0
+	 */
+	public void setCascadeCollections(boolean cascadeCollections) {
+		this.cascadeCollections = cascadeCollections;
+	}
+
+	/**
+	 * @param cascadePermissions
+	 * @since 4.6.0
+	 */
+	public void setCascadePermissions(boolean cascadePermissions) {
+		this.cascadePermissions = cascadePermissions;
+	}
+
+	/**
+	 * @return
+	 * @since 4.6.0
+	 */
+	public boolean isCascadeCollections() {
+		return cascadeCollections;
+	}
+
+	/**
+	 * @return
+	 * @since 4.6.0
+	 */
+	public boolean isCascadePermissions() {
+		return cascadePermissions;
 	}
 }

--- a/src/test/java/com/marklogic/client/ext/AbstractIntegrationTest.java
+++ b/src/test/java/com/marklogic/client/ext/AbstractIntegrationTest.java
@@ -82,6 +82,11 @@ public abstract class AbstractIntegrationTest {
 
 	protected final void verifyPermissions(String uri, String... permissionsRolesAndCapabilities) {
 		verifyMetadata(uri, metadata -> {
+			// TODO This will likely need to be modified once we shift the tests to not use an admin user, and thus
+			// the user will have to specify at least one update permission.
+			if (permissionsRolesAndCapabilities.length == 0) {
+				assertEquals(0, metadata.getPermissions().size());
+			}
 			for (int i = 0; i < permissionsRolesAndCapabilities.length; i += 2) {
 				String role = permissionsRolesAndCapabilities[i];
 				assertTrue(metadata.getPermissions().containsKey(role), "Did not find permissions with role: " +

--- a/src/test/java/com/marklogic/client/ext/file/CascadeCollectionsAndPermissionsTest.java
+++ b/src/test/java/com/marklogic/client/ext/file/CascadeCollectionsAndPermissionsTest.java
@@ -25,27 +25,31 @@ public class CascadeCollectionsAndPermissionsTest extends AbstractIntegrationTes
 	final private String PARENT_COLLECTION = "ParentCollection";
 	final private String CHILD_COLLECTION = "ChildCollection";
 
+
+	private GenericFileLoader loader;
+
 	@BeforeEach
-	public void setup() {
+	void setup() {
 		client = newClient(MODULES_DATABASE);
 		DatabaseClient modulesClient = client;
 		modulesClient.newServerEval().xquery("cts:uris((), (), cts:true-query()) ! xdmp:document-delete(.)").eval();
+		loader = new GenericFileLoader(client);
+		loader.setCascadeCollections(true);
+		loader.setCascadePermissions(true);
 	}
 
 	@Test
-	public void parentWithBothProperties() {
-		String directory = "src/test/resources/process-files/cascading-metadata-test/parent1-withCP";
-		GenericFileLoader loader = new GenericFileLoader(client);
-		loader.loadFiles(directory);
+	void parentWithBothProperties() {
+		loader.loadFiles("src/test/resources/process-files/cascading-metadata-test/parent1-withCP");
 
-		verifyCollections( "/child1_1-noCP/test.json", PARENT_COLLECTION);
-		verifyPermissions( "/child1_1-noCP/test.json", "rest-writer", "update");
+		verifyCollections("/child1_1-noCP/test.json", PARENT_COLLECTION);
+		verifyPermissions("/child1_1-noCP/test.json", "rest-writer", "update");
 
-		verifyCollections( "/child1_2-withCP/test.json", CHILD_COLLECTION);
-		verifyPermissions( "/child1_2-withCP/test.json", "rest-reader", "read");
+		verifyCollections("/child1_2-withCP/test.json", CHILD_COLLECTION);
+		verifyPermissions("/child1_2-withCP/test.json", "rest-reader", "read");
 
-		verifyCollections( "/child3_1-withCP/grandchild3_1_1-noCP/test.json", CHILD_COLLECTION);
-		verifyPermissions( "/child3_1-withCP/grandchild3_1_1-noCP/test.json", "rest-reader", "read");
+		verifyCollections("/child3_1-withCP/grandchild3_1_1-noCP/test.json", CHILD_COLLECTION);
+		verifyPermissions("/child3_1-withCP/grandchild3_1_1-noCP/test.json", "rest-reader", "read");
 
 		verifyCollections("/child1/child1.json", "ParentCollection");
 		verifyPermissions("/child1/child1.json", "rest-writer", "update");
@@ -58,21 +62,32 @@ public class CascadeCollectionsAndPermissionsTest extends AbstractIntegrationTes
 	}
 
 	@Test
-	public void parentWithNoProperties() {
-		String directory = "src/test/resources/process-files/cascading-metadata-test/parent2-noCP";
-		GenericFileLoader loader = new GenericFileLoader(client);
-		loader.loadFiles(directory);
+	void parentWithNoProperties() {
+		loader.loadFiles("src/test/resources/process-files/cascading-metadata-test/parent2-noCP");
 
-		verifyCollections( "/child2_1-withCP/test.json", CHILD_COLLECTION);
-		verifyPermissions( "/child2_1-withCP/test.json", "rest-reader", "read");
+		verifyCollections("/child2_1-withCP/test.json", CHILD_COLLECTION);
+		verifyPermissions("/child2_1-withCP/test.json", "rest-reader", "read");
 
-		verifyCollections( "/child2_2-noCP/test.json");
-		verifyPermissions( "/child2_2-noCP/test.json");
+		verifyCollections("/child2_2-noCP/test.json");
+		verifyPermissions("/child2_2-noCP/test.json");
 
-		verifyCollections( "/child2_3-withCnoP/test.json", PARENT_COLLECTION);
-		verifyPermissions( "/child2_3-withCnoP/test.json");
+		verifyCollections("/child2_3-withCnoP/test.json", PARENT_COLLECTION);
+		verifyPermissions("/child2_3-withCnoP/test.json");
 
-		verifyCollections( "/child2_3-withCnoP/grandchild2_3_1-withPnoC/test.json", PARENT_COLLECTION);
-		verifyPermissions( "/child2_3-withCnoP/grandchild2_3_1-withPnoC/test.json", "rest-reader", "read");
+		verifyCollections("/child2_3-withCnoP/grandchild2_3_1-withPnoC/test.json", PARENT_COLLECTION);
+		verifyPermissions("/child2_3-withCnoP/grandchild2_3_1-withPnoC/test.json", "rest-reader", "read");
+	}
+
+	/**
+	 * Verifies that by default, cascading is disabled. This is to preserve backwards compatibility in 4.x. We
+	 * expect to change this for 5.0.
+	 */
+	@Test
+	void cascadingDisabled() {
+		loader = new GenericFileLoader(client);
+
+		loader.loadFiles("src/test/resources/process-files/cascading-metadata-test/parent1-withCP");
+		verifyCollections("/child1_1-noCP/test.json");
+		verifyPermissions("/child1_1-noCP/test.json");
 	}
 }

--- a/src/test/java/com/marklogic/client/ext/modulesloader/impl/LoadModulesTest.java
+++ b/src/test/java/com/marklogic/client/ext/modulesloader/impl/LoadModulesTest.java
@@ -36,7 +36,9 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class LoadModulesTest extends AbstractIntegrationTest {
 
@@ -48,7 +50,7 @@ public class LoadModulesTest extends AbstractIntegrationTest {
 		client = newClient(MODULES_DATABASE);
 		client.newServerEval().xquery("cts:uris((), (), cts:true-query()) ! xdmp:document-delete(.)").eval();
 		modulesClient = client;
-		assertEquals(0, getUriCountInModulesDatabase(), "No new modules should have been created");
+		assertEquals(0, getUriCountInModulesDatabase(), "No modules should exist");
 
 		/**
 		 * Odd - the Client REST API doesn't allow for loading namespaces when the DatabaseClient has a database


### PR DESCRIPTION
ml-app-deployer will then introduce new properties to call the setters on GFL. 