### PR TITLE
Reworking TDE/QBV processors

### DIFF
--- a/src/test/java/com/marklogic/client/ext/AbstractIntegrationTest.java
+++ b/src/test/java/com/marklogic/client/ext/AbstractIntegrationTest.java
@@ -58,6 +58,14 @@ public abstract class AbstractIntegrationTest {
 		}
 	}
 
+	protected final DatabaseClient newContentClient() {
+		String currentDatabase = clientConfig.getDatabase();
+		clientConfig.setDatabase(CONTENT_DATABASE);
+		DatabaseClient client = configuredDatabaseClientFactory.newDatabaseClient(clientConfig);
+		clientConfig.setDatabase(currentDatabase);
+		return client;
+	}
+
 	protected DatabaseClient newClient(String database) {
 		String currentDatabase = clientConfig.getDatabase();
 		clientConfig.setDatabase(database);

--- a/src/test/java/com/marklogic/client/ext/schemasloader/impl/GenerateQbvTest.java
+++ b/src/test/java/com/marklogic/client/ext/schemasloader/impl/GenerateQbvTest.java
@@ -19,15 +19,15 @@ public class GenerateQbvTest extends AbstractSchemasTest {
 
 	@BeforeEach
 	void beforeEach() {
-		loader = new DefaultSchemasLoader(client, CONTENT_DATABASE);
+		// As a sanity check, verify that QBVs get generated when we tell DSL not to validate TDEs.
+		loader = new DefaultSchemasLoader(client, newContentClient(), false);
 	}
 
 	@Test
 	public void test() {
 		Path path = Paths.get("src", "test", "resources", "qbv-schemas");
 		List<DocumentFile> files = loader.loadSchemas(path.toString());
-		assertEquals(3, files.size(),
-			"Only the TDE templates should be in this list");
+		assertEquals(2, files.size(), "Only the TDE templates should be in this list");
 
 		ClientHelper helper = new ClientHelper(client);
 		List<String> tdeUris = helper.getUrisInCollection(TdeUtil.TDE_COLLECTION);

--- a/src/test/java/com/marklogic/client/ext/schemasloader/impl/LoadRulesetsTest.java
+++ b/src/test/java/com/marklogic/client/ext/schemasloader/impl/LoadRulesetsTest.java
@@ -30,7 +30,7 @@ public class LoadRulesetsTest extends AbstractSchemasTest {
 	@Test
 	public void test() {
 		// Pass in a TDE validation database to ensure that TDE validation doesn't happen for these files
-		DefaultSchemasLoader loader = new DefaultSchemasLoader(client, CONTENT_DATABASE);
+		DefaultSchemasLoader loader = new DefaultSchemasLoader(client, newContentClient());
 		List<DocumentFile> files = loader.loadSchemas(Paths.get("src", "test", "resources", "rulesets", "collection-test").toString());
 		assertEquals(2, files.size());
 

--- a/src/test/java/com/marklogic/client/ext/schemasloader/impl/LoadSchemasTest.java
+++ b/src/test/java/com/marklogic/client/ext/schemasloader/impl/LoadSchemasTest.java
@@ -33,7 +33,7 @@ public class LoadSchemasTest extends AbstractSchemasTest {
 
 	@Test
 	public void test() {
-		DefaultSchemasLoader loader = new DefaultSchemasLoader(client);
+		DefaultSchemasLoader loader = new DefaultSchemasLoader(client, null);
 		RestBatchWriter writer = (RestBatchWriter) loader.getBatchWriter();
 		assertEquals(1, writer.getThreadCount(), "Should default to 1 so that any error from loading a document " +
 			"into a schemas database is immediately thrown to the client");
@@ -55,7 +55,7 @@ public class LoadSchemasTest extends AbstractSchemasTest {
 
 	@Test
 	public void testTemplateBatchInsert() {
-		DefaultSchemasLoader loader = new DefaultSchemasLoader(client, CONTENT_DATABASE);
+		DefaultSchemasLoader loader = new DefaultSchemasLoader(client, newContentClient());
 		List<DocumentFile> files = loader.loadSchemas(Paths.get("src", "test", "resources", "good-schemas", "originals").toString());
 		assertEquals(2, files.size());
 
@@ -80,7 +80,7 @@ public class LoadSchemasTest extends AbstractSchemasTest {
 
 	@Test
 	public void invalidClientAndNoFilesToLoad() {
-		DefaultSchemasLoader loader = new DefaultSchemasLoader(newClient("invalid-database-doesnt-exist"));
+		DefaultSchemasLoader loader = new DefaultSchemasLoader(newClient("invalid-database-doesnt-exist"), null);
 		List<DocumentFile> files = loader.loadSchemas(Paths.get("src", "test", "resources", "no-schemas").toString());
 		assertEquals(0, files.size(),
 			"When there aren't any files to load, then no error should be thrown when the client is invalid (which in " +
@@ -89,7 +89,7 @@ public class LoadSchemasTest extends AbstractSchemasTest {
 
 	@Test
 	public void invalidClientWithFilesToLoad() {
-		DefaultSchemasLoader loader = new DefaultSchemasLoader(newClient("invalid-database-doesnt-exist"));
+		DefaultSchemasLoader loader = new DefaultSchemasLoader(newClient("invalid-database-doesnt-exist"), null);
 		FailedRequestException ex = assertThrows(FailedRequestException.class,
 			() -> loader.loadSchemas(Paths.get("src", "test", "resources", "good-schemas").toString()));
 

--- a/src/test/java/com/marklogic/client/ext/schemasloader/impl/ValidateTdeTemplatesTest.java
+++ b/src/test/java/com/marklogic/client/ext/schemasloader/impl/ValidateTdeTemplatesTest.java
@@ -36,8 +36,7 @@ public class ValidateTdeTemplatesTest extends AbstractSchemasTest {
 	@BeforeEach
 	public void setup() {
 		super.setup();
-		// Assumes that Documents points to Schemas as its schemas database
-		loader = new DefaultSchemasLoader(client, CONTENT_DATABASE);
+		loader = new DefaultSchemasLoader(client, newContentClient());
 	}
 
 	@Test

--- a/src/test/resources/qbv-bad-schemas/qbv/bad-authors.sjs
+++ b/src/test/resources/qbv-bad-schemas/qbv/bad-authors.sjs
@@ -1,1 +1,4 @@
+'use strict';
+const op = require('/MarkLogic/optic');
+
 op.fromView('Medical', 'Authors');

--- a/src/test/resources/qbv-no-tde-schemas/qbv/books.sjs
+++ b/src/test/resources/qbv-no-tde-schemas/qbv/books.sjs
@@ -1,1 +1,4 @@
+'use strict';
+const op = require('/MarkLogic/optic');
+
 op.fromView('Medical', 'Books').generateView('alternate', 'books');

--- a/src/test/resources/qbv-schemas/qbv/authors.sjs
+++ b/src/test/resources/qbv-schemas/qbv/authors.sjs
@@ -1,1 +1,4 @@
-op.fromView('Medical', 'Authors').generateView('alternate', 'authors');
+'use strict';
+const op = require('/MarkLogic/optic');
+
+op.fromView('Medical', 'Authors').generateView('alternate', 'authors')

--- a/src/test/resources/qbv-schemas/qbv/publications.xqy
+++ b/src/test/resources/qbv-schemas/qbv/publications.xqy
@@ -1,2 +1,6 @@
+xquery version "1.0-ml";
+
+import module namespace op="http://marklogic.com/optic" at "/MarkLogic/optic.xqy";
+
 op:from-view("Medical", "Publications")
    => op:generate-view("alternate", "publications")


### PR DESCRIPTION
Both are now using a content DatabaseClient so they don't have to do an additional eval/invokeFunction. 

This does involve significant changes to both TdeDocumentFileProcess and DefaultSchemasLoader, but those changes are based on an existing flaw, where a content database name was passed instead of an actual content DatabaseClient. 