### PR TITLE
Added support for key/trust store properties 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,11 +10,11 @@ plugins {
 
 	// For deploying the test app.
 	id 'net.saliman.properties' version '1.5.2'
-	id "com.marklogic.ml-gradle" version "4.5.2"
+	id "com.marklogic.ml-gradle" version "4.6.1"
 }
 
 group = "com.marklogic"
-version = "4.6-SNAPSHOT"
+version = "4.7-SNAPSHOT"
 
 java {
 	sourceCompatibility = 1.8
@@ -24,33 +24,33 @@ java {
 repositories {
 	mavenLocal()
 	maven {
-		url "https://nexus.marklogic.com/repository/maven-snapshots/"
+		url "https://bed-artifactory.bedford.progress.com:443/artifactory/ml-maven-snapshots/"
 	}
 	mavenCentral()
 }
 
 dependencies {
-	api 'com.marklogic:marklogic-client-api:6.3.0'
-	api 'com.marklogic:marklogic-xcc:11.0.3'
-	api 'org.springframework:spring-context:5.3.29'
+	api 'com.marklogic:marklogic-client-api:6.5-SNAPSHOT'
+	api 'com.marklogic:marklogic-xcc:11.1.0'
+	api 'org.springframework:spring-context:5.3.31'
 
 	implementation 'org.jdom:jdom2:2.0.6.1'
 
-	implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
+	implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.3'
 
 	// This is currently an implementation dependency, though perhaps should be an api dependency due to its usage in
 	// LoggingObject; not clear yet on whether the protected Logger in that class should make this an api dependency or not
 	implementation 'org.slf4j:slf4j-api:1.7.36'
 
-	testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
-	testImplementation 'org.springframework:spring-test:5.3.29'
+	testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
+	testImplementation 'org.springframework:spring-test:5.3.31'
 	testImplementation 'org.mockito:mockito-core:4.11.0'
 
 	// Used for testing loading modules from the classpath
 	testImplementation files("lib/modules.jar")
 
 	// Forcing Spring to use logback instead of commons-logging
-	testImplementation "ch.qos.logback:logback-classic:1.3.5" // Not using 1.4.x yet as it requires Java 11
+	testImplementation "ch.qos.logback:logback-classic:1.3.14" // Not using 1.4.x yet as it requires Java 11
 	testImplementation "org.slf4j:jcl-over-slf4j:1.7.36"
 	testImplementation "org.slf4j:slf4j-api:1.7.36"
 
@@ -73,12 +73,12 @@ test {
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {
-	classifier 'sources'
+	archiveClassifier = 'sources'
 	from sourceSets.main.allSource
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
-	classifier "javadoc"
+	archiveClassifier = "javadoc"
 	from javadoc
 }
 javadoc.failOnError = false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/marklogic/client/ext/DatabaseClientConfig.java
+++ b/src/main/java/com/marklogic/client/ext/DatabaseClientConfig.java
@@ -49,6 +49,15 @@ public class DatabaseClientConfig {
 	private String cloudApiKey;
 	private String basePath;
 
+	private String keyStorePath;
+	private String keyStorePassword;
+	private String keyStoreType;
+	private String keyStoreAlgorithm;
+	private String trustStorePath;
+	private String trustStorePassword;
+	private String trustStoreType;
+	private String trustStoreAlgorithm;
+
 	public DatabaseClientConfig() {
 	}
 
@@ -235,5 +244,149 @@ public class DatabaseClientConfig {
 	 */
 	public void setSamlToken(String samlToken) {
 		this.samlToken = samlToken;
+	}
+
+	/**
+	 *
+	 * @return
+	 * @since 4.7.0
+	 */
+	public String getKeyStorePath() {
+		return keyStorePath;
+	}
+
+	/**
+	 *
+	 * @param keyStorePath
+	 * @since 4.7.0
+	 */
+	public void setKeyStorePath(String keyStorePath) {
+		this.keyStorePath = keyStorePath;
+	}
+
+	/**
+	 *
+	 * @return
+	 * @since 4.7.0
+	 */
+	public String getKeyStorePassword() {
+		return keyStorePassword;
+	}
+
+	/**
+	 *
+	 * @param keyStorePassword
+	 * @since 4.7.0
+	 */
+	public void setKeyStorePassword(String keyStorePassword) {
+		this.keyStorePassword = keyStorePassword;
+	}
+
+	/**
+	 *
+	 * @return
+	 * @since 4.7.0
+	 */
+	public String getKeyStoreType() {
+		return keyStoreType;
+	}
+
+	/**
+	 *
+	 * @param keyStoreType
+	 * @since 4.7.0
+	 */
+	public void setKeyStoreType(String keyStoreType) {
+		this.keyStoreType = keyStoreType;
+	}
+
+	/**
+	 *
+	 * @return
+	 * @since 4.7.0
+	 */
+	public String getKeyStoreAlgorithm() {
+		return keyStoreAlgorithm;
+	}
+
+	/**
+	 *
+	 * @param keyStoreAlgorithm
+	 * @since 4.7.0
+	 */
+	public void setKeyStoreAlgorithm(String keyStoreAlgorithm) {
+		this.keyStoreAlgorithm = keyStoreAlgorithm;
+	}
+
+	/**
+	 *
+	 * @return
+	 * @since 4.7.0
+	 */
+	public String getTrustStorePath() {
+		return trustStorePath;
+	}
+
+	/**
+	 *
+	 * @param trustStorePath
+	 * @since 4.7.0
+	 */
+	public void setTrustStorePath(String trustStorePath) {
+		this.trustStorePath = trustStorePath;
+	}
+
+	/**
+	 *
+	 * @return
+	 * @since 4.7.0
+	 */
+	public String getTrustStorePassword() {
+		return trustStorePassword;
+	}
+
+	/**
+	 *
+	 * @param trustStorePassword
+	 * @since 4.7.0
+	 */
+	public void setTrustStorePassword(String trustStorePassword) {
+		this.trustStorePassword = trustStorePassword;
+	}
+
+	/**
+	 *
+	 * @return
+	 * @since 4.7.0
+	 */
+	public String getTrustStoreType() {
+		return trustStoreType;
+	}
+
+	/**
+	 *
+	 * @param trustStoreType
+	 * @since 4.7.0
+	 */
+	public void setTrustStoreType(String trustStoreType) {
+		this.trustStoreType = trustStoreType;
+	}
+
+	/**
+	 *
+	 * @return
+	 * @since 4.7.0
+	 */
+	public String getTrustStoreAlgorithm() {
+		return trustStoreAlgorithm;
+	}
+
+	/**
+	 *
+	 * @param trustStoreAlgorithm
+	 * @since 4.7.0
+	 */
+	public void setTrustStoreAlgorithm(String trustStoreAlgorithm) {
+		this.trustStoreAlgorithm = trustStoreAlgorithm;
 	}
 }

--- a/src/main/java/com/marklogic/client/ext/DefaultConfiguredDatabaseClientFactory.java
+++ b/src/main/java/com/marklogic/client/ext/DefaultConfiguredDatabaseClientFactory.java
@@ -48,7 +48,16 @@ public class DefaultConfiguredDatabaseClientFactory implements ConfiguredDatabas
 			.withSAMLToken(config.getSamlToken())
 			.withCloudApiKey(config.getCloudApiKey())
 			.withSSLProtocol(config.getSslProtocol())
-			.withSSLHostnameVerifier(config.getSslHostnameVerifier());
+			.withSSLHostnameVerifier(config.getSslHostnameVerifier())
+			// The following 8 were added for 4.7.0 based on Java Client 6.5.0
+			.withKeyStorePath(config.getKeyStorePath())
+			.withKeyStorePassword(config.getKeyStorePassword())
+			.withKeyStoreType(config.getKeyStoreType())
+			.withKeyStoreAlgorithm(config.getKeyStoreAlgorithm())
+			.withTrustStorePath(config.getTrustStorePath())
+			.withTrustStorePassword(config.getTrustStorePassword())
+			.withTrustStoreType(config.getTrustStoreType())
+			.withTrustStoreAlgorithm(config.getTrustStoreAlgorithm());
 
 		if (config.getSecurityContextType() != null) {
 			builder.withAuthType(config.getSecurityContextType().name());


### PR DESCRIPTION
No automated tests for this as it depends on an app server with 2-way SSL. The Java Client tests verify that the various builder methods work correctly. Relying on manual testing via ml-gradle for these changes. 